### PR TITLE
modified ADSyncQuery to add menu options for LocalDB alternatives

### DIFF
--- a/ADSyncDecrypt/ADSyncQuery/Program.cs
+++ b/ADSyncDecrypt/ADSyncQuery/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-
 using System.Data.SqlClient;
 using System.Text;
+using System.IO;
 
 namespace ADSyncQuery
 {
@@ -9,8 +9,39 @@ namespace ADSyncQuery
     {
         static void Main(string[] args)
         {
-            string connstring = string.Format("Data Source=(LocalDB)\\MSSQLLocalDB;AttachDbFilename=\"{0}\";Integrated Security=True;Connect Timeout=30", args[0]);
-            Console.WriteLine("Opening database {0}", args[0]);
+            Console.WriteLine("1: Use " + Environment.MachineName);
+            Console.WriteLine("2: Use LocalDB (Default)");
+            Console.WriteLine("3: Specify a server name");
+            Console.Write("Enter your choice (1, 2, or 3): ");
+            int choice = Convert.ToInt32(Console.ReadLine());
+
+            string dataSource = "";
+            switch (choice)
+            {
+                case 1:
+                    dataSource = Environment.MachineName;  // HOSTNAME
+                    break;
+                case 2:
+                    dataSource = "(LocalDB)\\MSSQLLocalDB"; // LocalDB
+                    break;
+                case 3:
+                    Console.Write("Enter the server name: ");
+                    dataSource = Console.ReadLine(); // custom server name
+                    break;
+                default:
+                    Console.WriteLine("Invalid choice. Exiting.");
+                    return;
+            }
+
+            Console.Write("Enter the full path to the file (or just the filename if it's in the current directory): ");
+            string filePath = Console.ReadLine();
+            if (!Path.IsPathRooted(filePath))
+            {
+                filePath = Path.Combine(Directory.GetCurrentDirectory(), filePath);
+            }
+
+            string connstring = string.Format("Data Source={0};AttachDbFilename=\"{1}\";Integrated Security=True;Connect Timeout=30", dataSource, filePath);
+            Console.WriteLine("Opening database {0}", filePath);
             using (SqlConnection conn = new SqlConnection(connstring))
             {
                 conn.Open();
@@ -27,7 +58,6 @@ namespace ADSyncQuery
                 reader.Read();
                 Console.WriteLine("Config: {0};{1};{2}",
                     reader[0].ToString(), reader[1].ToString(), reader[2].ToString());
-
             }
         }
     }


### PR DESCRIPTION
Created CLI menu options to enable MSSQL server alternatives to the default LocalDB option. Enables operators to avoid modifying and recompiling ADSyncQuery to contain a value other than LocalDB when attempting to read from a retrieved MDF database file (for cases where MSSQL is configured differently and LocalDB isn't found). Also added a CLI option to provide the full path to the MDF database file. This will also accept a filename by itself instead of a full file path if the file resides in the same folder ADSyncQuery was executed out of.