### PR TITLE
fixed error in splitting bytes and not string

### DIFF
--- a/adconnectdump.py
+++ b/adconnectdump.py
@@ -230,7 +230,7 @@ class ADSRemoteOperations(RemoteOperations):
             logging.info('Querying database for configuration data')
             dbpath = os.path.join(os.getcwd(), r"ADSync.mdf")
             output = subprocess.Popen(["ADSyncQuery.exe", dbpath], stdout=subprocess.PIPE).communicate()[0]
-            enumtarget = output.split('\n')
+            enumtarget = output.decode(codec).split('\n')
         for line in enumtarget:
             try:
                 ltype, data = line.strip().split(': ')


### PR DESCRIPTION
There was an error in reading the AdSyncQuery.exe output: 
![image](https://github.com/dirkjanm/adconnectdump/assets/30568019/b43a8726-227f-4084-9de0-7bf10750db31)


Added decoding to avoid that 