### PR TITLE
Add the ability to dynamically switch between ADSync and ADSync2019 databases

### DIFF
--- a/ADSyncDecrypt/ADSyncDecrypt/ADSyncDecrypt.csproj
+++ b/ADSyncDecrypt/ADSyncDecrypt/ADSyncDecrypt.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -8,7 +8,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ADSyncDecrypt</RootNamespace>
     <AssemblyName>ADSyncDecrypt</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />

--- a/ADSyncDecrypt/ADSyncDecrypt/App.config
+++ b/ADSyncDecrypt/ADSyncDecrypt/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ADSyncDecrypt/ADSyncDecrypt/Program.cs
+++ b/ADSyncDecrypt/ADSyncDecrypt/Program.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Security;
 using System.Security.Principal;
+using Microsoft.Win32;
 
 namespace ADSyncDecrypt
 {
@@ -71,9 +72,20 @@ namespace ADSyncDecrypt
             return dupeTokenHandle;
         }
 
+        static string DB_Configuration()
+        {
+            const string parametersKey = "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\ADSync\\Parameters";
+            string dBServer = (string)Registry.GetValue(parametersKey, "Server", "(LocalDB)");
+            string dBName = (string)Registry.GetValue(parametersKey, "DBName", "ADSync");
+            string dBInstance = (string)Registry.GetValue(parametersKey, "SQLInstance", ".\\ADSync2019");
+            string connection_string = "Data Source=" + dBServer + "\\" + dBInstance + ";Initial Catalog=" + dBName + ";Connect Timeout=30";
+
+            return connection_string;
+        }
+
         static void Main(string[] args)
         {
-            string connectionString = (args.Length == 0) ? "Data Source=(LocalDB)\\.\\ADSync2019;Initial Catalog=ADSync;Connect Timeout=30" : args[0];
+            string connectionString = (args.Length == 0) ? DB_Configuration() : args[0];
             Console.WriteLine("Opening database {0}", connectionString);
             using (SqlConnection conn = new SqlConnection(connectionString))
             {

--- a/ADSyncDecrypt/ADSyncGather/ADSyncGather.csproj
+++ b/ADSyncDecrypt/ADSyncGather/ADSyncGather.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ADSyncGather</RootNamespace>
     <AssemblyName>ADSyncGather</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ADSyncDecrypt/ADSyncGather/App.config
+++ b/ADSyncDecrypt/ADSyncGather/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ADSyncDecrypt/ADSyncGather/Program.cs
+++ b/ADSyncDecrypt/ADSyncGather/Program.cs
@@ -10,9 +10,20 @@ namespace ADSyncGather
 {
     class Program
     {
+        static string DB_Configuration()
+        {
+            const string parametersKey = "HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\ADSync\\Parameters";
+            string dBServer = (string)Registry.GetValue(parametersKey, "Server", "(LocalDB)");
+            string dBName = (string)Registry.GetValue(parametersKey, "DBName", "ADSync");
+            string dBInstance = (string)Registry.GetValue(parametersKey, "SQLInstance", ".\\ADSync2019");
+            string connection_string = "Data Source=" + dBServer + "\\" + dBInstance + ";Initial Catalog=" + dBName + ";Connect Timeout=30";
+
+            return connection_string;
+        }
+
         static void Main(string[] args)
         {
-            string connectionString = (args.Length == 0) ? "Data Source=(LocalDB)\\.\\ADSync2019;Initial Catalog=ADSync;Connect Timeout=30" : args[0];
+            string connectionString = (args.Length == 0) ? DB_Configuration() : args[0];
             Console.WriteLine("Opening database {0}", connectionString);
             using (SqlConnection conn = new SqlConnection(connectionString))
             {

--- a/ADSyncDecrypt/ADSyncQuery/ADSyncQuery.csproj
+++ b/ADSyncDecrypt/ADSyncQuery/ADSyncQuery.csproj
@@ -8,9 +8,10 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>ADSyncQuery</RootNamespace>
     <AssemblyName>ADSyncQuery</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ADSyncDecrypt/ADSyncQuery/App.config
+++ b/ADSyncDecrypt/ADSyncQuery/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/adconnectdump.py
+++ b/adconnectdump.py
@@ -74,10 +74,19 @@ class ADSRemoteOperations(RemoteOperations):
         try:
             self.__checkServiceStatus()
             logging.info('Downloading ADSync database files')
-            with open('ADSync.mdf','wb') as fh:
-                self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync2019\ADSync.mdf', fh.write)
-            with open('ADSync_log.LDF','wb') as fh:
-                self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync2019\ADSync_log.ldf', fh.write)
+            fileNames = []
+            for files in self.__smbConnection.listPath('C$',r'Program Files\Microsoft Azure AD Sync\Data\*'):
+                fileNames.append(files.get_longname())
+            if "ADSync.mdf" in fileNames:
+                with open('ADSync.mdf','wb') as fh:
+                    self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync.mdf', fh.write)
+                with open('ADSync_log.LDF','wb') as fh:
+                    self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync_log.ldf', fh.write)
+            else:
+                with open('ADSync.mdf','wb') as fh:
+                    self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync2019\ADSync.mdf', fh.write)
+                with open('ADSync_log.LDF','wb') as fh:
+                    self.__smbConnection.getFile('C$',r'Program Files\Microsoft Azure AD Sync\Data\ADSync2019\ADSync_log.ldf', fh.write)
         finally:
             self.__restore_adsync()
 


### PR DESCRIPTION
Hi guys !

This PR permits to dynamically retrieve the ADSync database connection string from the AD Connect server registry keys.
Depending on the installed version, the string can be either "ADSync" or "ADSync2019", and this value can be extracted from the registry, in addition to the other values.
Additionally, for the remote extraction with `ADSyncQuery`, the path of the `.mdf` and `.ldf` files also differs between the versions.

In parallel, the .NET version has also been updated to the 4.8. It seems to work fine.